### PR TITLE
disable AVX-512 instruction set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN wget --quiet "https://github.com/ablab/spades/releases/download/v3.13.1/SPAd
 # Install racon
 # (note: CPU-architecture dependent)
 RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/racon-v1.4.10.tar.gz" \
- && tar -zxvf racon-v1.4.10.tar.gz \
+ && tar -zxf racon-v1.4.10.tar.gz \
  && cd racon-v1.4.10 \
  && mkdir -p build \
  && cd build \
@@ -60,7 +60,7 @@ RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/rac
 # Install samtools
 
 RUN wget --quiet "https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2" \
- && tar -xjvf samtools-1.10.tar.bz2 \
+ && tar -xjf samtools-1.10.tar.bz2 \
  && cd /home/unicycler/samtools-1.10 \
  && ./configure --prefix=/usr/local --without-curses \
  && make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/aptible/ubuntu:16.04
+FROM quay.io/aptible/ubuntu:19.04
 
 MAINTAINER Christopher Smith <christopher@onecodex.com>
 
@@ -27,6 +27,7 @@ RUN apt-get update \
   unzip \
   wget --quiet \
   zlib1g-dev \
+  racon \
   && apt-get clean
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
@@ -40,22 +41,6 @@ RUN wget --quiet "https://github.com/ablab/spades/releases/download/v3.13.1/SPAd
   && ls SPAdes-3.13.1-Linux \
   && mv SPAdes-3.13.1-Linux/bin/* /usr/local/bin/ \
   && mv SPAdes-3.13.1-Linux/share/* /usr/local/share/
-
-# Install racon
-# (note: CPU-architecture dependent)
-RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/racon-v1.4.10.tar.gz" \
- && tar -zxf racon-v1.4.10.tar.gz \
- && cd racon-v1.4.10 \
- && mkdir -p build \
- && cd build \
- && cmake \
-   -D CMAKE_BUILD_TYPE=Release \
-   -D CMAKE_CXX_FLAGS="-march=haswell -mno-avx512f -mno-avx512pf -mno-avx512er -mno-avx512cd" \
-   .. \
- && make \
- && make install \
- && cd ../../ \
- && rm -r racon-v1.4.10
 
 # Install samtools
 
@@ -77,7 +62,7 @@ RUN wget --quiet "https://github.com/BenLangmead/bowtie2/releases/download/v2.3.
  && cd .. \
  && rm -r bowtie2*
 
-# Install Unicycler
+# Install Unicycler (this actually installs 4.8)
 # TODO: switch back to official repo once Racon bug is fixed
 RUN git clone https://github.com/onecodex/Unicycler.git \
  && cd /home/unicycler/Unicycler \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ RUN wget --quiet "https://github.com/samtools/samtools/releases/download/1.10/sa
 
 # Install bowtie2
 
-RUN wget --quiet "https://github.com/BenLangmead/bowtie2/releases/download/v2.3.4.1/bowtie2-2.3.4.1-linux-x86_64.zip" \
- && unzip bowtie2-2.3.4.1-linux-x86_64.zip \
- && cd /home/unicycler/bowtie2-2.3.4.1-linux-x86_64 \
+RUN wget --quiet "https://github.com/BenLangmead/bowtie2/releases/download/v2.3.5.1/bowtie2-2.3.5.1-linux-x86_64.zip" \
+ && unzip bowtie2-2.3.5.1-linux-x86_64.zip \
+ && cd /home/unicycler/bowtie2-2.3.5.1-linux-x86_64 \
  && mv bowtie2* /usr/local/bin  \
  && cd .. \
  && rm -r bowtie2*

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,23 +35,28 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 
 # Install SPAdes
 
-RUN wget --quiet "http://cab.spbu.ru/files/release3.12.0/SPAdes-3.12.0.tar.gz" \
- && tar -xzvf SPAdes-3.12.0.tar.gz \
- && cd SPAdes-3.12.0/ \
+RUN wget --quiet "https://github.com/ablab/spades/releases/download/v3.13.1/SPAdes-3.13.1.tar.gz" \
+ && tar -xzvf SPAdes-3.13.1.tar.gz \
+ && cd SPAdes-3.13.1/ \
  && PREFIX=/usr/local/ ./spades_compile.sh \
  && cd .. \
- && rm -rf SPAdes-3.12.0
+ && rm -rf SPAdes-3.13.1
 
 # Install racon
-
-RUN git clone --recursive https://github.com/isovic/racon.git racon \
- && mkdir -p /home/unicycler/racon/build \
- && cd /home/unicycler/racon/build \
- && cmake -DCMAKE_BUILD_TYPE=Release .. \
+# (note: CPU-architecture dependent)
+RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/racon-v1.4.10.tar.gz" \
+ && tar -zxvf racon-v1.4.10.tar.gz \
+ && cd racon-v1.4.10 \
+ && mkdir -p build \
+ && cd build \
+ && cmake \
+   -D CMAKE_BUILD_TYPE=Release \
+   -D CMAKE_CXX_FLAGS="-march=haswell -mno-avx512pf -mno-avx512er -mno-avx512pf -mno-avx512er -mno-avx512cd -mno-avx512f" \
+   .. \
  && make \
  && make install \
  && cd ../../ \
- && rm -r racon*
+ && rm -r racon-v1.4.10
 
 # Install samtools
 
@@ -74,10 +79,10 @@ RUN wget --quiet "https://github.com/BenLangmead/bowtie2/releases/download/v2.3.
  && rm -r bowtie2*
 
 # Install Unicycler
-
-RUN git clone https://github.com/rrwick/Unicycler.git \
+# TODO: switch back to official repo once Racon bug is fixed
+RUN git clone https://github.com/onecodex/Unicycler.git \
  && cd /home/unicycler/Unicycler \
- && git checkout v0.4.7 \
+ && git checkout audy-ensure-racon-ran-at-least-once \
  && python3 setup.py install \
  && cd .. \
  && rm -rf /home/unicycler/Unicycler

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,14 +60,14 @@ RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/rac
 
 # Install samtools
 
-RUN wget --quiet "https://github.com/samtools/samtools/releases/download/1.7/samtools-1.7.tar.bz2" \
- && tar -xjvf samtools-1.7.tar.bz2 \
- && cd /home/unicycler/samtools-1.7 \
+RUN wget --quiet "https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2" \
+ && tar -xjvf samtools-1.10.tar.bz2 \
+ && cd /home/unicycler/samtools-1.10 \
  && ./configure --prefix=/usr/local --without-curses \
  && make \
  && make install \
  && cd .. \
- && rm -r samtools-1.7*
+ && rm -r samtools-1.10*
 
 # Install bowtie2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN wget --quiet "https://github.com/lbcb-sci/racon/releases/download/1.4.10/rac
  && cd build \
  && cmake \
    -D CMAKE_BUILD_TYPE=Release \
-   -D CMAKE_CXX_FLAGS="-march=haswell -mno-avx512pf -mno-avx512er -mno-avx512pf -mno-avx512er -mno-avx512cd -mno-avx512f" \
+   -D CMAKE_CXX_FLAGS="-march=haswell -mno-avx512f -mno-avx512pf -mno-avx512er -mno-avx512cd" \
    .. \
  && make \
  && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,11 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 
 # Install SPAdes
 
-RUN wget --quiet "https://github.com/ablab/spades/releases/download/v3.13.1/SPAdes-3.13.1.tar.gz" \
- && tar -xzvf SPAdes-3.13.1.tar.gz \
- && cd SPAdes-3.13.1/ \
- && PREFIX=/usr/local/ ./spades_compile.sh \
- && cd .. \
- && rm -rf SPAdes-3.13.1
+RUN wget --quiet "https://github.com/ablab/spades/releases/download/v3.13.1/SPAdes-3.13.1-Linux.tar.gz" \
+  && tar -zxf SPAdes-3.13.1-Linux.tar.gz \
+  && ls SPAdes-3.13.1-Linux \
+  && mv SPAdes-3.13.1-Linux/bin/* /usr/local/bin/ \
+  && mv SPAdes-3.13.1-Linux/share/* /usr/local/share/
 
 # Install racon
 # (note: CPU-architecture dependent)

--- a/IMAGE
+++ b/IMAGE
@@ -1,1 +1,1 @@
-quay.io/refgenomics/docker-unicycler:v0.4.7-2
+quay.io/refgenomics/docker-unicycler:v0.4.7-audy-ensure-racon-ran-at-least-once

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # docker-unicycler [![Docker Repository on Quay](https://quay.io/repository/refgenomics/docker-unicycler/status "Docker Repository on Quay")](https://quay.io/repository/refgenomics/docker-unicycler)
 
-A Docker image for [rrwick/unicycler](https://github.com/rrwick/Unicycler). Releases for this repo, and the corresponding image tags, follow official releases for Unicycler.
+A Docker image for [rrwick/unicycler](https://github.com/rrwick/Unicycler).
+Releases for this repo, and the corresponding image tags, follow official
+releases for Unicycler.
+
+**Note**: We purposefully compile Racon without AVX-512 instructions as this
+will not run on certain ec2 instances.
 
 ## Usage
 


### PR DESCRIPTION
* [x] disable AVX-512 when compiling (so that the pipeline can run on most ec2 instances)
* [x] switch to a [fork of Unicycler] that fails if Racon fails (TODO: switch back if fix is merged upstream)
* [x] update some other dependencies while I'm at it (racon, spades)